### PR TITLE
Remove `passwords` and `oauth` tables from the downloadable copy of the DB

### DIFF
--- a/mcgj/mcgj.py
+++ b/mcgj/mcgj.py
@@ -123,6 +123,10 @@ def latest_db():
     tmp = sqlite3.connect(path.name)
     cur = db.connect()
     cur.backup(tmp)
+    # Downloadable copy of the db should not include auth info about real users
+    with tmp:
+        tmp.execute("DROP TABLE IF EXISTS passwords")
+        tmp.execute("DROP TABLE IF EXISTS oauth")
     tmp.close()
     cur.close()
     return send_file(path, as_attachment=True, download_name="mcgj-latest.db")


### PR DESCRIPTION
## Summary
After this change, the SQLite database served from the "download latest MCGJDB" link will not contain auth information about real users.  Right now that means the `passwords` and `oauth` tables will be dropped.  In the future, if other auth methods are added, their info should probably also be dropped by adding `DROP TABLE` statements similar to the ones in this PR.

## Tested
Just a basic local check:
1. Download latest mcgjdb from prod and place it at `<repo_root>/mcgj/dev.db`
2. Create `<repo_root>/.env` file with these contents:
   ```
   CLIENT_ID=[redacted]
   CLIENT_SECRET=[redacted]
   CLIENT_CALLBACK=http://127.0.0.1:5000/auth/callback
   FLASK_ENV=development
   FLASK_APP=mcgj
   ```
3. Run the Flask application:
   ```
   uv run -m flask run
   ```
5. Visit the application in a web browser at http://localhost:5000, log in (via oauth in my case), and click the link to download the latest MCGJDB.  I called it `mcgj-latest_sanitized.db`.
6. Ensure that the `passwords` and `oauth` tables don't exist in the downloaded db:
   ```
   $ sqlite3 mcgj-latest_sanitized.db 
   SQLite version 3.37.2 2022-01-06 13:25:41
   Enter ".help" for usage hints.
   sqlite> .schema
   CREATE TABLE sqlite_sequence(name,seq);
   CREATE TABLE users (
       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       create_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
       update_date TIMESTAMP,
       name TEXT,
       nickname TEXT
   );
   CREATE TABLE sessions (
       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       create_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
       update_date TIMESTAMP,
       name TEXT NOT NULL,
       current_round INTEGER
   );
   CREATE TABLE tracks (
       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       create_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
       update_date TIMESTAMP,
       cue_date TIMESTAMP,
       person TEXT,
       user_id INTEGER,
       title TEXT,
       artist TEXT,
       url TEXT,
       art_url TEXT,
       session_id INTEGER NOT NULL,
       played INTEGER,
       round_number INTEGER,
       FOREIGN KEY (user_id) REFERENCES users(id),
       FOREIGN KEY (session_id) REFERENCES sessions(id)
   );
   sqlite> 
   ```