### PR TITLE
Add timestamp to filename of the downloaded db

### DIFF
--- a/mcgj/mcgj.py
+++ b/mcgj/mcgj.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import UTC
 import sqlite3
 import tempfile
 from itertools import chain, zip_longest
@@ -129,7 +130,8 @@ def latest_db():
         tmp.execute("DROP TABLE IF EXISTS oauth")
     tmp.close()
     cur.close()
-    return send_file(path, as_attachment=True, download_name="mcgj-latest.db")
+    timestamp = datetime.datetime.now(UTC).strftime("%Y%m%d_%H%M%S%z")
+    return send_file(path, as_attachment=True, download_name=f"mcgj-{timestamp}.db")
 
 
 @bp.route("/update_profile", methods=["POST"])


### PR DESCRIPTION
## Summary
Changes the filename served by the "Download the MCGJDB" link (`/latest_db` route) from `mcgj-latest.db` to something like `mcgj-YYYYMMDD_hhmmss+0000.db` (UTC time).

## Tested
Ran a local dev instance, clicked the link, got the filename `mcgj-20260225_040304+0000.db`.