### PR TITLE
fix nickname setting

### DIFF
--- a/mcgj/mcgj.py
+++ b/mcgj/mcgj.py
@@ -139,7 +139,8 @@ def update_profile():
     nickname = request.get("nickname")
     if nickname == "":
         nickname = None
-    user.nickname = nickname
+    if nickname is not None:
+        user.nickname = nickname
     old_pw = request.get("old_password")
     if old_pw == "":
         old_pw = None

--- a/mcgj/mcgj.py
+++ b/mcgj/mcgj.py
@@ -136,13 +136,19 @@ def latest_db():
 @login_required
 def update_profile():
     user = current_user
-    user.nickname = request.form["nickname"] if request.form["nickname"] != "" else None
-    old_pw = request.form["old_password"]
-    old_pw = old_pw if old_pw != "" else None
-    new_pw = request.form["new_password"]
-    new_pw = new_pw if new_pw != "" else None
-    confirm_pw = request.form["confirm_password"]
-    confirm_pw = confirm_pw if confirm_pw != "" else None
+    nickname = request.get("nickname")
+    if nickname == "":
+        nickname = None
+    user.nickname = nickname
+    old_pw = request.get("old_password")
+    if old_pw == "":
+        old_pw = None
+    new_pw = request.get("new_password")
+    if new_pw == "":
+        new_pw = None
+    confirm_pw = request.get("confirm_password")
+    if confirm_pw == "":
+        confirm_pw = None
     if old_pw is not None and new_pw is not None and confirm_pw is not None:
         old_hash = db.query(
             "SELECT password_hash FROM passwords WHERE id = ?", [user.id], one=True

--- a/mcgj/templates/edit_profile.html
+++ b/mcgj/templates/edit_profile.html
@@ -10,7 +10,7 @@
 <br>
 
 <form class="edit-form" method="POST" action="/update_profile">
-  <label for="nickname">Nickname</label><input type="text" name="nickname" value="{{user.nickname if user.nickname != None}}" required>
+  <label for="nickname">Nickname</label><input type="text" name="nickname" value="{{user.nickname if user.nickname != None}}">
   {% if has_password %}
   <label for="old_password">old password</label><input type="password" name="old_password">
   <label for="new_password">new password</label><input type="password" name="new_password">

--- a/mcgj/templates/edit_profile.html
+++ b/mcgj/templates/edit_profile.html
@@ -10,11 +10,13 @@
 <br>
 
 <form class="edit-form" method="POST" action="/update_profile">
-  <label for="nickname">Nickname</label><input type="text" name="nickname" value="{{user.nickname if user.nickname != None}}">
   {% if has_password %}
+  <label for="nickname">Nickname</label><input type="text" name="nickname" value="{{user.nickname if user.nickname != None}}">
   <label for="old_password">old password</label><input type="password" name="old_password">
   <label for="new_password">new password</label><input type="password" name="new_password">
   <label for="confirm_password">confirm password</label><input type="password" name="confirm_password">
+  {% else %}
+  <label for="nickname">Nickname</label><input type="text" name="nickname" value="{{user.nickname if user.nickname != None}}" required>
   {% endif %}
   <input class="action-btn" type="submit" value="Save">
 </form>


### PR DESCRIPTION
With the addition of support for password auth, the `update_profile` function was looking for the form it received from the client to contain fields like "old_password", which were not present in the form if the currently-logged-in user was using OAuth to authenticate. The function attempted to access those fields using bracket operators, which would throw an exception if they were not present, which caused OAuth users to receive a 400 when they tried to change their nickname. This PR
 * uses `.get("old_password")` and the like to retrieve fields safely
 * makes the "nickname" field not-required for password users, because requiring it when changing password is weird