### PR TITLE
fix session editing: don't try to save spotify_url for sessions

### DIFF
--- a/mcgj/mcgj.py
+++ b/mcgj/mcgj.py
@@ -334,9 +334,6 @@ def update_session(session_id):
     """Submit an update to a track"""
     session = Session(with_id=session_id)
     session.name = request.form["name"] if request.form["name"] != "" else None
-    session.spotify_url = (
-        request.form["spotify_url"] if request.form["spotify_url"] != "" else None
-    )
     session.current_round = (
         request.form["current_round"] if request.form["current_round"] != "" else None
     )

--- a/mcgj/templates/edit_session.html
+++ b/mcgj/templates/edit_session.html
@@ -6,7 +6,6 @@
 <h1>Edit Session {{session.id}}</h1>
 <form class="edit-form" method="POST" action="/sessions/{{session.id}}/update">
     <label for="name">Session Name</label><input type="text" name="name" value="{{session.name if session.name != None}}" required>
-    <label for="spotify_url">Spotify URL</label><input type="text" name="spotify_url" value="{{session.spotify_url if session.spotify_url != None}}">
     <label for="current_round">Current Round</label><input type="text" name="current_round" value="{{session.current_round if session.current_round != None}}">
     <input class="action-btn" type="submit" value="Save">
 </form>


### PR DESCRIPTION
This is something that was actually introduced in the last big PR that "cleaned up" (aka "fucked up") the DB schema, where the `sessions` table dropped the "spotify_url" column, since no rows contained it, but the `edit_sessions` endpoint expected to exist.